### PR TITLE
Add tcp+tls support

### DIFF
--- a/src/pyfaktory/client.py
+++ b/src/pyfaktory/client.py
@@ -81,6 +81,7 @@ class Client:
         self.host = parsed_url.hostname
         self.port = parsed_url.port or C.DEFAULT_PORT
         self.password = parsed_url.password
+        self.scheme = parsed_url.scheme
 
         self.sock: socket.socket
         self.timeout = timeout
@@ -123,6 +124,10 @@ class Client:
 
         self.logger.info('Openning connection...')
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if self.scheme == 'tcp+tls':
+            import ssl
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+            self.sock = context.wrap_socket(self.sock, server_hostname=self.host)
 
         self.sock.settimeout(self.timeout)
         self.sock.connect((self.host, self.port))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,6 +20,7 @@ class TestClientConstructor:
 
         assert client.host == 'my-server'
         assert client.port == 7419
+        assert client.scheme == 'tcp'
         assert client.password is None
         assert client.role == 'both'
         assert client.timeout == timeout
@@ -35,6 +36,7 @@ class TestClientConstructor:
 
         assert client.host == 'env-server'
         assert client.port == 7400
+        assert client.scheme == 'tcp'
 
     def test_ignore_env_faktory_url(self, monkeypatch):
         env_faktory_url = 'tcp://env-server:7400'
@@ -44,6 +46,7 @@ class TestClientConstructor:
 
         assert client.host == 'arg-server'
         assert client.port == 7411
+        assert client.scheme == 'tcp'
 
     def test_use_default_faktory_url(self, monkeypatch):
         monkeypatch.delenv('FAKTORY_URL', raising=False)
@@ -52,13 +55,22 @@ class TestClientConstructor:
 
         assert client.host == 'localhost'
         assert client.port == 7419
+        assert client.scheme == 'tcp'
 
     def test_set_password(self):
         client = Client(faktory_url='tcp://:sdg145sd@q!@@foo-server:7419')
 
         assert client.host == 'foo-server'
         assert client.port == 7419
+        assert client.scheme == 'tcp'
         assert client.password == 'sdg145sd@q!@'
+    
+    def test_use_tcp_tls(self):
+        client = Client(faktory_url='tcp+tls://foo-server:7419')
+
+        assert client.host == 'foo-server'
+        assert client.port == 7419
+        assert client.scheme == 'tcp+tls'
 
     def test_consumer_specific_fields(self):
         consumer_specific_fields = {


### PR DESCRIPTION
This is based on the recommendations for [TLS support in the Faktory docs](https://github.com/contribsys/faktory/wiki/Security#encryption-via-tls) as well as the mention of on-going [TLS support in the supported clients](https://www.mikeperham.com/2018/01/08/faktory-0.7.0-released/#faktory-will-not-terminate-tls). 

