### PR TITLE
Move some logging to debug level from info.

### DIFF
--- a/src/pyfaktory/client.py
+++ b/src/pyfaktory/client.py
@@ -263,8 +263,8 @@ class Client:
     def _heartbeat(self):
         while self.state in [State.IDENTIFIED, State.QUIET]:
             with self.rlock:
-                self.logger.info(
-                    f"Sending heartbeat to server, next heartbeat in {self.beat_period} seconds"
+                self.logger.debug(
+                    f'Sending heartbeat to server, next heartbeat in {self.beat_period} seconds'
                 )
                 self._beat(rss_kb=self.rss_kb)
             time.sleep(self.beat_period)

--- a/src/pyfaktory/consumer.py
+++ b/src/pyfaktory/consumer.py
@@ -146,7 +146,7 @@ class Consumer:
                 sentry_sdk.capture_exception(err)
 
             err_type, err_value, err_traceback = sys.exc_info()
-            self.logger.info(
+            self.logger.warning(
                 f"Task (job {future.job_id}) raised {err_type}: {err_value}"
             )
             self.logger.debug(
@@ -192,7 +192,7 @@ class Consumer:
 
                 if self.pending_tasks_count < self.concurrency:
                     queues_tmp = self.get_queues()
-                    self.logger.info(f"Fetching from queues: {queues_tmp}")
+                    self.logger.debug(f'Fetching from queues: {queues_tmp}')
                     # If no jobs are found, _fatch will block for up
                     # to 2 seconds on the first queue provided.
                     job = self.client._fetch(queues_tmp)
@@ -231,10 +231,10 @@ class Consumer:
         try:
             self.pool.close()
             self.pool.join(timeout=self.grace_period)
+            self.logger.info(f'End of the grace period. Stopping.')
         except KeyboardInterrupt:
             self.logger.info("Second KeyboardInterrupt, stopping immediately")
 
-        self.logger.info(f"End of the grace period. Stopping.")
         sys.exit(1)
 
 


### PR DESCRIPTION
We were finding the worker to be pretty noisy at the INFO log level, specifically during the routine consumer polling. I shifted most of the repetitive logging in to DEBUG level and kept INFO for non-repetitive logging.

There is a INFO level log I upgraded to WARNING regarding a failed job, and I also adjusted the logging around the KeyboardInterrupt handling to ensure we didn't falsely claim the grace period was done when we got a second interrupt.

@ghilesmeddour Please give me feedback on this. It is an admittedly opinionated change, but I think it's informed by our production and development use so far.