### PR TITLE
Enable TCP Keep-Alives

### DIFF
--- a/src/pyfaktory/client.py
+++ b/src/pyfaktory/client.py
@@ -135,7 +135,9 @@ class Client:
             context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             self.sock = context.wrap_socket(self.sock, server_hostname=self.host)
 
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         self.sock.settimeout(self.timeout)
+        
         self.sock.connect((self.host, self.port))
 
         # The very first message from server


### PR DESCRIPTION
As referenced in https://github.com/contribsys/faktory/issues/273#issuecomment-576463404, TCP Keep-Alives are used to keep a connection marked as active. While neither the worker nor heartbeat threads have a moment in which the connection goes quiet, we've seen behaviour matching the original issue.

This changes enables TCP Keep-Alives as a precaution.