### PR TITLE
Add IPv6 support

### DIFF
--- a/src/pyfaktory/consumer.py
+++ b/src/pyfaktory/consumer.py
@@ -214,6 +214,7 @@ class Consumer:
                         future.add_done_callback(self.task_done)
                     else:
                         self.logger.debug("Queues are empty.")
+                        time.sleep(0.1)
                 else:
                     # TODO: maybe use Event object instead of sleep
                     time.sleep(0.1)


### PR DESCRIPTION
Currently, `pyfaktory` only has support for IPv4 socket connections. However, some VPCs such as Fly.io only support internal networking over IPv6 which would require custom connections to be able to support this library.

This PR updates the `socket` configuration to enable dual-stack (IPv4 and IPv6) socket connections. This enables support for both IPv4 and IPv6 connections to Faktory. This PR also includes a fallback to IPv4 if dual-stack connections are not supported.

In order to enable this behavior, the following changes have been made to the internals:
- Add 100ms sleep on empty queues
  * Aggressive polling causes connection instability over IPv6
- Improve error handling when server closes connection (empty response)