### PR TITLE
dont assign None to multiprocessing context

### DIFF
--- a/src/pyfaktory/consumer.py
+++ b/src/pyfaktory/consumer.py
@@ -64,7 +64,7 @@ class Consumer:
         concurrency: int = 4,
         grace_period: int = C.DEFAULT_GRACE_PERIOD,
         sentry_capture_exception: bool = False,
-        context: Optional[multiprocessing.context.BaseContext] = None,
+        context: Optional[multiprocessing.context.BaseContext] = multiprocessing,
     ) -> None:
         self.logger = logging.getLogger(name="FaktoryConsumer")
 


### PR DESCRIPTION
The pebble ProcessPool expects a multiprocessing context object when a context is passed.

If this is not configured in pyfaktory, a default None value is given, which throws an exception from Pebble:

AttributeError: 'NoneType' object has no attribute 'Pipe'.

Changing the default None to passing the multiprocessing module (which Pebble defines as the default parameter value when not explicitly used) 