### PR TITLE
fix: use sendall() instead of send() to prevent partial writes

### DIFF
--- a/src/pyfaktory/client.py
+++ b/src/pyfaktory/client.py
@@ -244,7 +244,7 @@ class Client:
         return True
 
     def _send(self, command: str):
-        self.sock.send(command.encode("utf-8"))
+        self.sock.sendall(command.encode("utf-8"))
         self.logger.debug(f"C: {command}")
 
     def _receive(self) -> str:


### PR DESCRIPTION
## Problem

`Client._send` uses `socket.send()` which may transmit fewer bytes than requested for large payloads. The return value (number of bytes actually sent) is ignored, so when the payload exceeds the TCP send buffer (~64-256KB depending on OS), the trailing bytes — including the `\r\n` protocol terminator — are silently dropped.

This causes a deadlock:
1. Server blocks on `ReadString('\n')` waiting for the terminator
2. Client blocks on `recv()` waiting for the response
3. Both sides wait until the socket timeout (default 30s)

## Fix

Replace `socket.send()` with `socket.sendall()`, which guarantees all bytes are transmitted or raises an exception.

```diff
-        self.sock.send(command.encode("utf-8"))
+        self.sock.sendall(command.encode("utf-8"))
```

## Context

We hit this in production pushing `PUSH` commands with ~200KB job payloads. Small jobs worked fine (fit in a single `send()` call), large jobs consistently timed out. Switching to `sendall()` resolved the issue.

Reference: [Python docs for socket.send()](https://docs.python.org/3/library/socket.html#socket.socket.send) — *"Returns the number of bytes sent. Applications are responsible for checking that all data has been sent."*