### PR TITLE
fix: handle null bulk string in push_bulk to avoid JSONDecodeError

### DIFF
--- a/src/pyfaktory/producer.py
+++ b/src/pyfaktory/producer.py
@@ -28,7 +28,9 @@ class Producer:
 
     def push_bulk(self, jobs: List[Job]) -> Dict:
         msg = self.client._pushb([j.model_dump(exclude_none=True) for j in jobs])
-        _, data = helper.RESP.parse_bulk_string(msg)
+        n_bytes, data = helper.RESP.parse_bulk_string(msg)
+        if n_bytes == -1:
+            return {}
         return json.loads(data)
 
     def batch_new(self, batch: Batch) -> bool:

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from pyfaktory import Client, Producer
+from pyfaktory.models import Job
 
 
 class TestProducerConstructor:
@@ -10,3 +13,32 @@ class TestProducerConstructor:
 
         _ = Producer(client=Client(role="producer"))
         _ = Producer(client=Client(role="both"))
+
+
+class TestProducerPushBulk:
+    def test_push_bulk_returns_empty_dict_on_null_bulk_string_stripped(self):
+        """push_bulk returns {} when server returns $-1 (stripped, as returned by _receive)."""
+        mock_client = MagicMock()
+        mock_client.role = "producer"
+        mock_client._pushb.return_value = "$-1"
+        producer = Producer(client=mock_client)
+        result = producer.push_bulk([Job(jobtype="MyJob", args=[])])
+        assert result == {}
+
+    def test_push_bulk_returns_empty_dict_on_null_bulk_string_with_crlf(self):
+        """push_bulk returns {} when server returns $-1\r\n (unstripped null bulk string)."""
+        mock_client = MagicMock()
+        mock_client.role = "producer"
+        mock_client._pushb.return_value = "$-1\r\n"
+        producer = Producer(client=mock_client)
+        result = producer.push_bulk([Job(jobtype="MyJob", args=[])])
+        assert result == {}
+
+    def test_push_bulk_returns_parsed_json_on_valid_response(self):
+        """push_bulk parses and returns the JSON response normally."""
+        mock_client = MagicMock()
+        mock_client.role = "producer"
+        mock_client._pushb.return_value = '$15\r\n{"jids":["abc"]}'
+        producer = Producer(client=mock_client)
+        result = producer.push_bulk([Job(jobtype="MyJob", args=[])])
+        assert result == {"jids": ["abc"]}


### PR DESCRIPTION
My hypothesis based on errors I am seeing: When the server returns `$-1\r\n` for PUSHB, parse_bulk_string returns `(-1, "")` and `json.loads("")` raises JSONDecodeError. Guard against this by checking `n_bytes == -1` and returning `{}` — the same pattern [_fetch](https://github.com/ghilesmeddour/faktory_worker_python/blob/b1643b588dad39748e0716638b46a73d74bd1945/src/pyfaktory/client.py#L466-L469) already uses for the identical response.

Adds tests for both the stripped `($-1)` and unstripped `($-1\r\n)` forms of the null bulk string, and for the normal JSON response path.

Fixes https://github.com/ghilesmeddour/faktory_worker_python/issues/25